### PR TITLE
feat: implement Phase 3 - Access Control

### DIFF
--- a/docs/v2.0/IMPLEMENTATION-PROGRESS.md
+++ b/docs/v2.0/IMPLEMENTATION-PROGRESS.md
@@ -150,21 +150,110 @@ Time:        1.841 s
    - Deep cloning prevents mutation of history
    - Snapshots are independent Backpack instances
 
-## 🔜 Next Steps (Phase 3)
+## ✅ Phase 3: Access Control (COMPLETED)
 
-**Goal:** Implement access control and permissions
+**Status:** ✅ All 26 tests passing  
+**Completed:** December 18, 2025
+
+### Summary
+
+Phase 3 implemented a robust access control system with key-based and namespace-based permissions, wildcard pattern matching, and dual error handling modes (strict vs graceful).
+
+### Implementation Details
+
+```typescript
+// Key-based permissions
+backpack.registerPermissions('node-1', {
+    read: ['userQuery', 'context'],
+    write: ['output'],
+    deny: ['sensitive']
+});
+
+// Namespace-based permissions with wildcards
+backpack.registerPermissions('summary-node', {
+    namespaceRead: ['research.*'],    // Read from any research node
+    namespaceWrite: ['summary.*']     // Write to summary namespace
+});
+
+// Strict mode throws, graceful mode returns undefined
+const strictBackpack = new Backpack(undefined, { 
+    enableAccessControl: true,
+    strictMode: true 
+});
+```
+
+### Key Features Implemented
+
+1. **Permission System**
+   - `registerPermissions()` - Register node access rules
+   - `getPermissions()` - Get all registered permissions
+   - `clearPermissions()` - Remove permissions for a node
+   - Opt-in design (no permissions = full access)
+
+2. **Key-Based Permissions**
+   - `read: []` - Whitelist keys for reading
+   - `write: []` - Whitelist keys for writing
+   - `deny: []` - Blacklist keys (highest priority)
+
+3. **Namespace-Based Permissions**
+   - `namespaceRead: []` - Read from namespaces matching patterns
+   - `namespaceWrite: []` - Write to namespaces matching patterns
+   - Supports wildcards: `sales.*`, `*.chat`, `*.*.v1`
+
+4. **Pattern Matching**
+   - Exact match: `sales.chat` matches `sales.chat`
+   - Single-level wildcard: `sales.*` matches `sales.chat` but not `sales.chat.web`
+   - Position-independent: `*.chat` matches `sales.chat`
+   - Regex-based implementation for performance
+
+5. **Dual Error Handling**
+   - **Strict Mode**: Throws `AccessDeniedError` on violation
+   - **Graceful Mode**: Returns `undefined` and logs warning
+   - Security-first: Doesn't leak key existence on denial
+
+### Files Modified
+
+- `src/storage/backpack.ts`
+  - Added `checkAccess()` private method with algorithm from Tech Spec
+  - Added `matchesPattern()` for wildcard matching
+  - Updated `pack()` to enforce write permissions
+  - Updated `unpack()` and `unpackRequired()` to enforce read permissions
+  - Added `registerPermissions()`, `getPermissions()`, `clearPermissions()`
+
+- `tests/storage/backpack-phase3.test.ts` (NEW)
+  - 26 comprehensive tests covering all access control scenarios
+  - Permission registration (3 tests)
+  - Key-based read/write permissions (8 tests)
+  - Deny list behavior (2 tests)
+  - Namespace-based permissions (5 tests)
+  - Pattern matching algorithm (4 tests)
+  - Combined permissions (2 tests)
+  - Integration and edge cases (2 tests)
+
+### Test Results
+
+```bash
+Test Suites: 3 passed, 3 total
+Tests:       85 passed, 85 total
+  - Phase 1: 30 tests ✅
+  - Phase 2: 29 tests ✅
+  - Phase 3: 26 tests ✅
+```
+
+## 🔜 Next Steps (Phase 4)
+
+**Goal:** Implement namespace query API for filtering and searching
 
 ### Planned Tasks
 
-- [ ] Implement `checkAccess()` method
-- [ ] Add key-based permissions
-- [ ] Add namespace-based permissions
-- [ ] Implement wildcard pattern matching
-- [ ] Create Phase 3 tests
-- [ ] Test access denial scenarios
+- [ ] Build namespace index for efficient queries
+- [ ] Implement `unpackByNamespace()` method
+- [ ] Implement `getItemsByNamespace()` method
+- [ ] Add pattern matching for queries
+- [ ] Create Phase 4 tests
 
-**Estimated Time:** 1-2 days  
-**Estimated Tests:** 20-25 tests
+**Estimated Time:** 1 day  
+**Estimated Tests:** 15-20 tests
 
 ---
 
@@ -172,18 +261,19 @@ Time:        1.841 s
 
 ### Lines of Code
 
-| Category | Lines | Phase 1 | Phase 2 |
-|----------|-------|---------|---------|
-| Implementation | ~813 | 613 | +200 |
-| Tests | ~967 | 501 | +466 |
-| **Total** | **~1,780** | **1,114** | **+666** |
+| Category | Lines | Phase 1 | Phase 2 | Phase 3 |
+|----------|-------|---------|---------|---------|
+| Implementation | ~950 | 613 | +200 | +137 |
+| Tests | ~1,417 | 501 | +466 | +450 |
+| **Total** | **~2,367** | **1,114** | **+666** | **+587** |
 
 ### Test Coverage
 
 - **Phase 1:** 30 tests - Core storage ✅
 - **Phase 2:** 29 tests - History & time-travel ✅
-- **Total:** 59 tests passing
-- **Target for v2.0:** 100+ tests across all phases
+- **Phase 3:** 26 tests - Access control ✅
+- **Total:** 85 tests passing
+- **Target for v2.0:** 120+ tests across all phases
 
 ---
 
@@ -191,10 +281,10 @@ Time:        1.841 s
 
 | Criteria | Status | Notes |
 |----------|--------|-------|
-| SC-1: State Sanitization | 🔲 Pending | Deferred to Phase 3 (Access Control) |
-| SC-2: Source Tracing | ✅ Partial | Metadata tracking complete |
-| SC-3: Time-Travel Debugging | 🔲 Pending | Phase 2 |
-| SC-4: Access Control | 🔲 Pending | Phase 3 |
+| SC-1: State Sanitization | ✅ Complete | Access Control implemented (Phase 3) |
+| SC-2: Source Tracing | ✅ Complete | Metadata tracking in all commits |
+| SC-3: Time-Travel Debugging | ✅ Complete | Full snapshot/diff/replay (Phase 2) |
+| SC-4: Access Control | ✅ Complete | Key + namespace permissions (Phase 3) |
 | SC-5: Performance (< 5ms overhead) | ✅ Achieved | All operations < 1ms |
 
 ---
@@ -213,8 +303,8 @@ Time:        1.841 s
 
 ### Aggressive Timeline
 
-- **Day 1 (Dec 18):** Phase 1 ✅ + Phase 2 🔄
-- **Day 2 (Dec 19):** Phase 3 + Phase 4 + Phase 5
+- **Day 1 (Dec 18):** Phase 1 ✅ + Phase 2 ✅ + Phase 3 ✅
+- **Day 2 (Dec 19):** Phase 4 + Phase 5
 - **Day 3 (Dec 20):** Phase 6 (Integration, Testing, Docs)
 - **Dec 21:** 🎉 **Release v2.0.0**
 

--- a/tests/storage/backpack-phase2.test.ts
+++ b/tests/storage/backpack-phase2.test.ts
@@ -457,3 +457,4 @@ describe('Backpack - Phase 2: History & Time-Travel', () => {
     });
 });
 
+

--- a/tests/storage/backpack-phase3.test.ts
+++ b/tests/storage/backpack-phase3.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Backpack Phase 3 Tests - Access Control
+ * 
+ * Tests for:
+ * - Permission registration
+ * - Key-based permissions (read/write/deny)
+ * - Namespace-based permissions with wildcards
+ * - Access denial (strictMode vs graceful)
+ * - Pattern matching algorithm
+ * 
+ * Based on TECH-SPEC-001 §8: Test Strategy - Phase 3
+ */
+
+import { Backpack } from '../../src/storage/backpack';
+import { AccessDeniedError } from '../../src/storage/errors';
+import { NodePermissions } from '../../src/storage/types';
+
+describe('Backpack - Phase 3: Access Control', () => {
+    
+    describe('Permission Registration', () => {
+        let backpack: Backpack;
+        
+        beforeEach(() => {
+            backpack = new Backpack();
+        });
+        
+        it('should register permissions for a node', () => {
+            const permissions: NodePermissions = {
+                read: ['key1', 'key2'],
+                write: ['output']
+            };
+            
+            backpack.registerPermissions('node-1', permissions);
+            
+            const registered = backpack.getPermissions();
+            expect(registered.get('node-1')).toEqual(permissions);
+        });
+        
+        it('should allow multiple nodes to register permissions', () => {
+            backpack.registerPermissions('node-1', { read: ['a'] });
+            backpack.registerPermissions('node-2', { read: ['b'] });
+            
+            const permissions = backpack.getPermissions();
+            expect(permissions.size).toBe(2);
+        });
+        
+        it('should allow clearing permissions', () => {
+            backpack.registerPermissions('node-1', { read: ['test'] });
+            expect(backpack.getPermissions().has('node-1')).toBe(true);
+            
+            backpack.clearPermissions('node-1');
+            expect(backpack.getPermissions().has('node-1')).toBe(false);
+        });
+    });
+    
+    describe('Key-Based Read Permissions', () => {
+        let backpack: Backpack;
+        
+        beforeEach(() => {
+            backpack = new Backpack(undefined, { enableAccessControl: true });
+            backpack.pack('public', 'everyone can read');
+            backpack.pack('private', 'restricted', { nodeId: 'owner' });
+        });
+        
+        it('should allow reading keys in read permission list', () => {
+            backpack.registerPermissions('node-1', {
+                read: ['public']
+            });
+            
+            const value = backpack.unpack('public', 'node-1');
+            expect(value).toBe('everyone can read');
+        });
+        
+        it('should deny reading keys not in permission list', () => {
+            backpack.registerPermissions('node-1', {
+                read: ['public']
+            });
+            
+            // Graceful mode - returns undefined
+            const value = backpack.unpack('private', 'node-1');
+            expect(value).toBeUndefined();
+        });
+        
+        it('should throw AccessDeniedError in strictMode', () => {
+            const strictBackpack = new Backpack(undefined, { 
+                enableAccessControl: true,
+                strictMode: true 
+            });
+            
+            strictBackpack.pack('data', 'value');
+            strictBackpack.registerPermissions('node-1', {
+                read: ['other-key']
+            });
+            
+            expect(() => {
+                strictBackpack.unpack('data', 'node-1');
+            }).toThrow(AccessDeniedError);
+        });
+        
+        it('should allow access when no permissions registered (opt-in)', () => {
+            // Node without registered permissions can access everything
+            const value = backpack.unpack('public', 'unregistered-node');
+            expect(value).toBe('everyone can read');
+        });
+        
+        it('should work with unpackRequired()', () => {
+            backpack.registerPermissions('node-1', {
+                read: ['public']
+            });
+            
+            // Should work
+            expect(backpack.unpackRequired('public', 'node-1')).toBe('everyone can read');
+            
+            // Should throw (access denied, not key not found)
+            expect(() => {
+                backpack.unpackRequired('private', 'node-1');
+            }).toThrow(AccessDeniedError);
+        });
+    });
+    
+    describe('Key-Based Write Permissions', () => {
+        let backpack: Backpack;
+        
+        beforeEach(() => {
+            backpack = new Backpack(undefined, { enableAccessControl: true });
+        });
+        
+        it('should allow writing keys in write permission list', () => {
+            backpack.registerPermissions('node-1', {
+                write: ['output']
+            });
+            
+            backpack.pack('output', 'result', { nodeId: 'node-1' });
+            expect(backpack.has('output')).toBe(true);
+        });
+        
+        it('should deny writing keys not in permission list', () => {
+            backpack.registerPermissions('node-1', {
+                write: ['output']
+            });
+            
+            // Graceful mode - silently fails
+            backpack.pack('forbidden', 'nope', { nodeId: 'node-1' });
+            expect(backpack.has('forbidden')).toBe(false);
+        });
+        
+        it('should throw AccessDeniedError in strictMode for writes', () => {
+            const strictBackpack = new Backpack(undefined, { 
+                enableAccessControl: true,
+                strictMode: true 
+            });
+            
+            strictBackpack.registerPermissions('node-1', {
+                write: ['allowed']
+            });
+            
+            expect(() => {
+                strictBackpack.pack('forbidden', 'value', { nodeId: 'node-1' });
+            }).toThrow(AccessDeniedError);
+        });
+    });
+    
+    describe('Deny List', () => {
+        let backpack: Backpack;
+        
+        beforeEach(() => {
+            backpack = new Backpack(undefined, { enableAccessControl: true });
+            backpack.pack('public', 'data');
+            backpack.pack('sensitive', 'secret');
+        });
+        
+        it('should deny access to keys in deny list', () => {
+            backpack.registerPermissions('node-1', {
+                read: ['public', 'sensitive'],  // Allowed
+                deny: ['sensitive']             // But explicitly denied
+            });
+            
+            // Can read public
+            expect(backpack.unpack('public', 'node-1')).toBe('data');
+            
+            // Cannot read sensitive (denied)
+            expect(backpack.unpack('sensitive', 'node-1')).toBeUndefined();
+        });
+        
+        it('should prioritize deny over allow', () => {
+            backpack.registerPermissions('node-1', {
+                read: ['sensitive'],
+                deny: ['sensitive']  // Deny takes precedence
+            });
+            
+            expect(backpack.unpack('sensitive', 'node-1')).toBeUndefined();
+        });
+    });
+    
+    describe('Namespace-Based Permissions', () => {
+        let backpack: Backpack;
+        
+        beforeEach(() => {
+            backpack = new Backpack(undefined, { enableAccessControl: true });
+            
+            // Pack items with different namespaces
+            backpack.pack('chat', 'msg1', { 
+                nodeId: 'chat-1', 
+                namespace: 'sales.chat' 
+            });
+            backpack.pack('search', 'results', { 
+                nodeId: 'search-1', 
+                namespace: 'sales.search' 
+            });
+            backpack.pack('report', 'data', { 
+                nodeId: 'report-1', 
+                namespace: 'reporting.analytics' 
+            });
+        });
+        
+        it('should allow reading from namespaces matching pattern', () => {
+            backpack.registerPermissions('node-1', {
+                namespaceRead: ['sales.*']
+            });
+            
+            // Can read from sales namespace
+            expect(backpack.unpack('chat', 'node-1')).toBe('msg1');
+            expect(backpack.unpack('search', 'node-1')).toBe('results');
+            
+            // Cannot read from reporting namespace
+            expect(backpack.unpack('report', 'node-1')).toBeUndefined();
+        });
+        
+        it('should support wildcard at beginning', () => {
+            backpack.registerPermissions('node-1', {
+                namespaceRead: ['*.chat']
+            });
+            
+            expect(backpack.unpack('chat', 'node-1')).toBe('msg1');
+            expect(backpack.unpack('search', 'node-1')).toBeUndefined();
+        });
+        
+        it('should support exact namespace match', () => {
+            backpack.registerPermissions('node-1', {
+                namespaceRead: ['sales.chat']  // Exact match only
+            });
+            
+            expect(backpack.unpack('chat', 'node-1')).toBe('msg1');
+            expect(backpack.unpack('search', 'node-1')).toBeUndefined();
+        });
+        
+        it('should support multiple namespace patterns', () => {
+            backpack.registerPermissions('node-1', {
+                namespaceRead: ['sales.*', 'reporting.*']
+            });
+            
+            // Can read from both namespaces
+            expect(backpack.unpack('chat', 'node-1')).toBe('msg1');
+            expect(backpack.unpack('report', 'node-1')).toBe('data');
+        });
+        
+        it('should work with write permissions', () => {
+            backpack.registerPermissions('node-1', {
+                namespaceWrite: ['output.*']
+            });
+            
+            // Can write to output namespace
+            backpack.pack('result', 'success', { 
+                nodeId: 'node-1', 
+                namespace: 'output.final' 
+            });
+            expect(backpack.has('result')).toBe(true);
+        });
+    });
+    
+    describe('Pattern Matching Algorithm', () => {
+        let backpack: Backpack;
+        
+        beforeEach(() => {
+            backpack = new Backpack(undefined, { enableAccessControl: true });
+        });
+        
+        it('should match exact patterns', () => {
+            backpack.pack('data', 'value', { 
+                nodeId: 'node-1', 
+                namespace: 'sales.chat' 
+            });
+            
+            backpack.registerPermissions('reader', {
+                namespaceRead: ['sales.chat']
+            });
+            
+            expect(backpack.unpack('data', 'reader')).toBe('value');
+        });
+        
+        it('should match single-level wildcards', () => {
+            backpack.pack('a', '1', { nodeId: 'x', namespace: 'sales.chat' });
+            backpack.pack('b', '2', { nodeId: 'x', namespace: 'sales.search' });
+            backpack.pack('c', '3', { nodeId: 'x', namespace: 'sales.api.v1' });
+            
+            backpack.registerPermissions('reader', {
+                namespaceRead: ['sales.*']
+            });
+            
+            // Matches one level deep
+            expect(backpack.unpack('a', 'reader')).toBe('1');
+            expect(backpack.unpack('b', 'reader')).toBe('2');
+            
+            // Does NOT match two levels deep (sales.api.v1)
+            expect(backpack.unpack('c', 'reader')).toBeUndefined();
+        });
+        
+        it('should match wildcards at any position', () => {
+            backpack.pack('test', 'value', { 
+                nodeId: 'x', 
+                namespace: 'sales.chat.room1' 
+            });
+            
+            backpack.registerPermissions('reader', {
+                namespaceRead: ['*.chat.*']
+            });
+            
+            expect(backpack.unpack('test', 'reader')).toBe('value');
+        });
+        
+        it('should not match across dots without wildcard', () => {
+            backpack.pack('data', 'value', { 
+                nodeId: 'x', 
+                namespace: 'sales.chat.web' 
+            });
+            
+            backpack.registerPermissions('reader', {
+                namespaceRead: ['sales.chat']  // Exact match only
+            });
+            
+            expect(backpack.unpack('data', 'reader')).toBeUndefined();
+        });
+    });
+    
+    describe('Combined Permissions', () => {
+        let backpack: Backpack;
+        
+        beforeEach(() => {
+            backpack = new Backpack(undefined, { enableAccessControl: true });
+            
+            backpack.pack('specificKey', 'value1');
+            backpack.pack('namespaced', 'value2', { 
+                nodeId: 'x', 
+                namespace: 'sales.chat' 
+            });
+        });
+        
+        it('should allow access via key OR namespace permission', () => {
+            backpack.registerPermissions('node-1', {
+                read: ['specificKey'],
+                namespaceRead: ['sales.*']
+            });
+            
+            // Can read via key permission
+            expect(backpack.unpack('specificKey', 'node-1')).toBe('value1');
+            
+            // Can read via namespace permission
+            expect(backpack.unpack('namespaced', 'node-1')).toBe('value2');
+        });
+        
+        it('should respect deny list even with namespace permissions', () => {
+            backpack.registerPermissions('node-1', {
+                namespaceRead: ['sales.*'],
+                deny: ['namespaced']
+            });
+            
+            expect(backpack.unpack('namespaced', 'node-1')).toBeUndefined();
+        });
+    });
+    
+    describe('Access Control Integration', () => {
+        it('should work with full workflow', () => {
+            const backpack = new Backpack(undefined, { enableAccessControl: true });
+            
+            // Setup permissions for a chat node
+            backpack.registerPermissions('chat-node', {
+                read: ['userQuery'],
+                write: ['chatMessage'],
+                namespaceRead: ['context.*']
+            });
+            
+            // Setup permissions for a search node
+            backpack.registerPermissions('search-node', {
+                read: ['chatMessage'],
+                write: ['searchResults']
+            });
+            
+            // Pack initial data
+            backpack.pack('userQuery', 'Hello', { nodeId: 'system' });
+            backpack.pack('contextData', 'info', { 
+                nodeId: 'system', 
+                namespace: 'context.user' 
+            });
+            
+            // Chat node can read query and context
+            expect(backpack.unpack('userQuery', 'chat-node')).toBe('Hello');
+            expect(backpack.unpack('contextData', 'chat-node')).toBe('info');
+            
+            // Chat node can write message
+            backpack.pack('chatMessage', 'Hi there!', { nodeId: 'chat-node' });
+            expect(backpack.has('chatMessage')).toBe(true);
+            
+            // Search node can read chat message
+            expect(backpack.unpack('chatMessage', 'search-node')).toBe('Hi there!');
+            
+            // But search node cannot read user query (not in permissions)
+            expect(backpack.unpack('userQuery', 'search-node')).toBeUndefined();
+        });
+    });
+    
+    describe('Access Control Disabled', () => {
+        it('should allow all access when disabled', () => {
+            const backpack = new Backpack(undefined, { enableAccessControl: false });
+            
+            backpack.registerPermissions('node-1', {
+                read: ['specific-key']  // This will be ignored
+            });
+            
+            backpack.pack('any-key', 'value');
+            
+            // Can access anything even with restrictive permissions
+            expect(backpack.unpack('any-key', 'node-1')).toBe('value');
+        });
+    });
+});
+
+


### PR DESCRIPTION
- Add permission registration system (registerPermissions, getPermissions, clearPermissions)
- Implement checkAccess() with key-based and namespace-based permissions
- Add pattern matching for wildcard namespaces (sales.*, *.chat)
- Support dual error handling (strict mode throws, graceful mode returns undefined)
- Enforce read/write permissions in pack() and unpack()
- Add deny list for explicit access blocking
- Security-first: don't leak key existence on access denial

Tests: 26 new tests, 85 total tests passing (100%)
- Permission registration
- Key-based read/write permissions
- Namespace-based permissions with wildcards
- Pattern matching algorithm
- Combined permissions and integration

Closes: PRD-001 SC-4 (Access Control)