### PR TITLE
chore: switch to Trusted Publishing for npm (remove NPM_TOKEN)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -85,11 +85,9 @@ jobs:
             echo "✅ Version $PACKAGE_VERSION is new. Ready to publish!"
           fi
       
-      # 9. Publish to npm
+      # 9. Publish to npm (using Trusted Publishing via OIDC)
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       
       # 10. Success message
       - name: Success notification


### PR DESCRIPTION
Use OIDC-based Trusted Publishing instead of long-lived tokens. More secure: no secrets to manage, automatic GitHub authentication.

npm will authenticate via GitHub Actions OIDC token automatically. The 'id-token: write' permission enables this.